### PR TITLE
praatcon.exe no longer available tmp fix

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/PraatR.Rproj
+++ b/PraatR.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: knitr
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/R/praat.R
+++ b/R/praat.R
@@ -381,7 +381,7 @@ SystemName = Sys.info()["sysname"] # "Windows", "Linux", or "Darwin" (=Mac)
 if( OSType=="windows" & SystemName=="Windows" ){
 	UserOS = "Windows" # For later down below in the code
 	# Make list of possible file paths and find which ones exist
-	PossiblePraatPaths = paste(LibraryDirectories,InterveningSlashes,"PraatR/praatcon.exe",sep="")
+	PossiblePraatPaths = paste(LibraryDirectories,InterveningSlashes,"PraatR/praat.exe",sep="")
 	ExistingPraatPaths = file.exists(PossiblePraatPaths)
 	# If praatcon.exe can't be found anywhere, issue an error message and stop computation
 	if( sum(ExistingPraatPaths)==0 ){ stop("Could not find praatcon.exe. Make sure PraatR is properly installed.") }


### PR DESCRIPTION
Hi,

because a colleague of mine just needed an old Gist I put together that uses PraatR under her Windows 10 machine (see here for that Gist: https://gist.github.com/raphywink/2512752a1efa56951f04) I discovered that PraatR doesn't work under Windows any more as praatcon.exe no longer exists and it's functionality has been integrated into the praat.exe (see section 5 here:  http://www.fon.hum.uva.nl/praat/download_win.html).

Here http://www.aaronalbin.com/praatr/ under Step 2 you say to place the praatcon.exe into the PraatR installation directory and here https://github.com/usagi5886/PraatR/blob/master/R/praat.R#L384 you assemble the path to that .exe. I simply replaced the praatcon.exe string with the praat.exe which means the user has to place a copy of the praat.exe into the PraatR directory. This seems to work...

Generally I think it is a bit hacky to place something within the installation folder of an R package (have fun explaining that to the CRAN gods ;-)). A better solution would maybe be to search the `Program Files` / `Program Files(x86)` directories for the praat.exe and let the user optionally pass in the path to the executable as an argument to the `praat(..., path2exe="C:/path/2/praat.ext")` command.

greetings from EMU-SDMS land :-)

Raphael
